### PR TITLE
Version 1.3

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -164,7 +164,7 @@ function petals_custom_colours() {
 				color: <?php echo esc_attr( get_theme_mod( 'petals_link_colour' ) ); ?>;
 			}
 			
-		    .sticky {
+		    	.sticky {
 				border-left: '4px solid <?php echo esc_attr( get_theme_mod( 'petals_link_colour' ) ); ?>';
 			}
 			
@@ -194,6 +194,30 @@ function petals_scripts() {
 	}
 }
 add_action( 'wp_enqueue_scripts', 'petals_scripts' );
+
+/**
+ * Enqueue Customizer styling.
+ */
+function petals_customizer_styling() { ?>
+	<style>
+		#accordion-panel-petals_theme_options .accordion-section-title:after,
+		#accordion-panel-petals_theme_options .accordion-section-title:focus,
+		#customize-controls #accordion-panel-petals_theme_options.control-section:hover>.accordion-section-title,
+		#sub-accordion-panel-petals_theme_options .accordion-section-title:after,
+		#sub-accordion-panel-petals_theme_options .control-section:hover>.accordion-section-title,
+		#sub-accordion-panel-petals_theme_options .control-section>.accordion-section-title:focus {
+			color: #EF6079FF !important;
+			border-left-color: #EF6079FF !important;
+		}
+		
+		#customize-theme-controls #accordion-panel-petals_theme_options.control-section .accordion-section-title:hover:after,
+		#sub-accordion-panel-petals_theme_options .accordion-section-title:hover:after {
+			color: #f5002b !important;
+		}
+	</style>
+	<?php
+}
+add_action( 'customize_controls_print_styles', 'petals_customizer_styling', 999 );
 
 /**
  * Implement the Custom Header feature.

--- a/header.php
+++ b/header.php
@@ -8,12 +8,11 @@
  *
  * @package Petals
  */
-
 ?>
 <!DOCTYPE HTML>
 <html <?php language_attributes(); ?>>
 <head>
-	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta charset="<?php bloginfo('charset'); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<link rel="profile" href="https://gmpg.org/xfn/11">
 	<?php wp_head(); ?>
@@ -23,142 +22,163 @@
 <?php wp_body_open(); ?>
 <div id="page" class="site">
 	<header id="masthead" class="site-header">
-	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'petals' ); ?></a>
+	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e('Skip to content', 'petals'); ?></a>
 
 		<nav id="site-navigation" class="main-navigation">
 			<button aria-controls="primary-menu" aria-expanded="false" class="menu-toggle"><svg class="menu-toggle-icon"><path d="M3 18h18v-2H3v2zm0-5h18v-2H3v2zm0-7v2h18V6"/></svg></button>
 				<div class="site-branding">
 			<?php
-			if ( is_front_page() && is_home() ) :
-				?>
-				<h1 class="site-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
+if (is_front_page() && is_home()):
+?>
+				<h1 class="site-title"><a href="<?php echo esc_url(home_url('/')); ?>" rel="home"><?php bloginfo('name'); ?></a></h1>
 		</div><!-- .site-branding -->
-			<?php endif; ?>
-			<h1 class="site-title menu-title"><a href="<?php echo esc_url( home_url( '/' ) ); ?>" rel="home"><?php bloginfo( 'name' ); ?></a></h1>
 			<?php
-			wp_nav_menu( array(
-				'theme_location' => 'menu-1',
-				'menu_id'        => 'primary-menu',
-			) );
-			?>
+endif; ?>
+			<h1 class="site-title menu-title"><a href="<?php echo esc_url(home_url('/')); ?>" rel="home"><?php bloginfo('name'); ?></a></h1>
+			<?php
+wp_nav_menu(array('theme_location' => 'menu-1', 'menu_id' => 'primary-menu',));
+?>
 		</nav>
-		<?php if ( is_front_page() ) : ?>
+		<?php if (is_front_page()): ?>
 			<?php the_custom_logo(); ?>
 			<?php
-			$petals_description = get_bloginfo( 'description', 'display' );
-			if ( ( $petals_description || is_customize_preview() ) && get_theme_mod( 'petals_panel_header' ) == 0 ) :
-				if ( function_exists( 'jetpack_social_menu' ) ) jetpack_social_menu(); ?>
+    $petals_description = get_bloginfo('description', 'display');
+    if (($petals_description || is_customize_preview()) && get_theme_mod('petals_panel_header') == 0):
+        if (function_exists('jetpack_social_menu')) jetpack_social_menu(); ?>
 				<p class="site-description"><?php echo $petals_description; /* WPCS: xss ok. */ ?></p>
-			<?php endif; ?>
+			<?php
+    endif; ?>
 		
-		<?php if ( get_theme_mod( 'petals_panel_header' ) == 1 ) { ?>
-			<div class="front-panel-wrapper centrebg" style="background-image: url(<?php echo esc_url( header_image() ) ?>)">
-		<?php } else ?>
+		<?php if (get_theme_mod('petals_panel_header') == 1) { ?>
+			<div class="front-panel-wrapper centrebg" style="background-image: url(<?php echo esc_url(header_image()) ?>)">
+		<?php
+    } else ?>
 			<div class="front-panel-empty-wrapper">
 				
 		<div class="front-panel">
-	<?php if ( get_theme_mod( 'petals_blob', 1 ) == 1 && get_theme_mod( 'petals_panel_header' ) == 0 ) : ?> <svg class="front-panel-blob" width="800" height="800" viewBox="0 0 600 600">
+	<?php if (get_theme_mod('petals_blob', 1) == 1 && get_theme_mod('petals_panel_header') == 0): ?> <svg class="front-panel-blob" width="800" height="800" viewBox="0 0 600 600">
   <g transform="translate(300,300)">
     <path d="M133,-198.4C176.2,-179.1,217.7,-148.8,230.1,-108.8C242.4,-68.9,225.6,-19.4,210.2,24.3C194.7,68,180.5,106.1,156.4,137.7C132.3,169.3,98.4,194.5,60.4,205.7C22.4,216.8,-19.8,214,-67.9,209.7C-115.9,205.3,-169.8,199.6,-191.1,169C-212.5,138.3,-201.3,82.8,-204.8,31.9C-208.3,-19,-226.5,-65.4,-213.6,-99.2C-200.8,-133.1,-156.9,-154.5,-116.1,-174.8C-75.3,-195.2,-37.7,-214.6,3.6,-220.2C44.9,-225.8,89.7,-217.6,133,-198.4Z" fill="#EF6079FF"/>
   </g>
 </svg>
-	<?php endif; ?>
-			<h6 class="small-panel-text"> <?php echo esc_attr( get_theme_mod('petals_small_text', __('This can be edited from your Customizer', 'petals') ) ); ?> </h6>
-			<h1 class="top-panel-text"> <?php echo esc_attr( get_theme_mod('petals_top_text', __('Wildlife & Floral Exhibition', 'petals') ) ); ?> </h1>
-			<h3 class ="bottom-panel-text"> <?php echo esc_attr( get_theme_mod('petals_bottom_text', __('Members Exclusive', 'petals') ) ); ?> </h3>
-			<?php if ( get_theme_mod( 'petals_panel_button' ) == 1 ) : ?> 
-			<a class="panel-button button" href="<?php echo esc_attr( get_theme_mod('petals_panel_buttonlink', __('Enter your own button here', 'petals') ) ); ?>">
-					<?php echo esc_attr( get_theme_mod('petals_panel_buttontext', __('Enter your own button here', 'petals') ) ); ?>
+	<?php
+    endif; ?>
+			<h6 class="small-panel-text"> <?php echo esc_attr(get_theme_mod('petals_small_text', __('This can be edited from your Customizer', 'petals'))); ?> </h6>
+			<h1 class="top-panel-text"> <?php echo esc_attr(get_theme_mod('petals_top_text', __('Wildlife & Floral Exhibition', 'petals'))); ?> </h1>
+			<h3 class ="bottom-panel-text"> <?php echo esc_attr(get_theme_mod('petals_bottom_text', __('Members Exclusive', 'petals'))); ?> </h3>
+			<?php if (get_theme_mod('petals_panel_button') == 1): ?> 
+			<a class="panel-button button" href="<?php echo esc_attr(get_theme_mod('petals_panel_buttonlink', __('Enter your own button here', 'petals'))); ?>">
+					<?php echo esc_attr(get_theme_mod('petals_panel_buttontext', __('Enter your own button here', 'petals'))); ?>
 			</a>
-			<?php endif; ?>
+			<?php
+    endif; ?>
 			</div>
-			<?php if ( get_theme_mod( 'petals_panel_header' ) == 0 ) { ?>
+			<?php if (get_theme_mod('petals_panel_header') == 0) { ?>
 			<img class="custom-header" src="
 			<?php header_image(); ?>" width="<?php get_custom_header()->width; ?>" height="<?php get_custom_header()->height; ?>" 
 			alt="">
-				<?php } ?> <!-- #site-navigation -->
+				<?php
+    } ?> <!-- #site-navigation -->
 		</div>
 	</header><!-- #masthead -->
-	<?php if  ( get_theme_mod( 'petals_display_promotion', 1 ) == 1 )  : ?>
+	<?php if (get_theme_mod('petals_display_promotion', 1) == 1): ?>
 	<div class="petals-promotion">
-		<?php if ( get_theme_mod( 'petals_promotion_image' ) ) : ?>
-		<div class="promotion-image centrebg" style="background-image: url(<?php echo esc_url( get_theme_mod('petals_promotion_image') ); ?>)">
-		<?php endif; ?>
-		<?php if ( ! get_theme_mod( 'petals_promotion_image' ) ) : ?>
-		<div class="promotion-image centrebg" style="background-image: url(<?php echo esc_url( get_template_directory_uri().'/resources/rain.png' ) ?>) ">
-		<?php endif; ?>
+		<?php if (get_theme_mod('petals_promotion_image')): ?>
+		<div class="promotion-image centrebg" style="background-image: url(<?php echo esc_url(get_theme_mod('petals_promotion_image')); ?>)">
+		<?php
+        endif; ?>
+		<?php if (!get_theme_mod('petals_promotion_image')): ?>
+		<div class="promotion-image centrebg" style="background-image: url(<?php echo esc_url(get_template_directory_uri() . '/resources/rain.png') ?>) ">
+		<?php
+        endif; ?>
 			<div class="promotion-text">
-			<h1 class="promotion-title"> <?php echo esc_attr( get_theme_mod('petals_promotion_heading', __('Discover what\'s available', 'petals') ) ); ?> </h1>
-			<h3 class ="promotion-subtitle"> <?php echo esc_attr( get_theme_mod('petals_promotion_subtitle', __('From birds to plants, there\'s a world to explore', 'petals') ) ); ?> </h3>
-					<?php if ( get_theme_mod( 'petals_promotion_button', 1 ) == 1 ) : ?> 
-			<a class="promotion-button panel-button" href="<?php echo esc_url( get_theme_mod('petals_promotion_button_link', '#' ) ); ?>">
-					<?php echo esc_attr( get_theme_mod('petals_promotion_button_text', __('Explore now!', 'petals' ) ) ); ?>
+			<h1 class="promotion-title"> <?php echo esc_attr(get_theme_mod('petals_promotion_heading', __('Discover what\'s available', 'petals'))); ?> </h1>
+			<h3 class ="promotion-subtitle"> <?php echo esc_attr(get_theme_mod('petals_promotion_subtitle', __('From birds to plants, there\'s a world to explore', 'petals'))); ?> </h3>
+					<?php if (get_theme_mod('petals_promotion_button', 1) == 1): ?> 
+			<a class="promotion-button panel-button" href="<?php echo esc_url(get_theme_mod('petals_promotion_button_link', '#')); ?>">
+					<?php echo esc_attr(get_theme_mod('petals_promotion_button_text', __('Explore now!', 'petals'))); ?>
 			</a>
-			<?php endif; ?>
+			<?php
+        endif; ?>
 			</div>
 		</div>
 	</div>
-	<?php endif; ?>
-	<?php if ( ! is_home() ) : ?>
+	<?php
+    endif; ?>
+	<?php if (!is_home()): ?>
 	<div class="petals-block-wrapper">
-	<?php if ( get_theme_mod( 'petals_display_block_one', 1 ) == 1 ) : ?>
+	<?php if (get_theme_mod('petals_display_block_one', 1) == 1): ?>
 		<div class="petals-block-one">
-			<?php if ( get_theme_mod( 'petals_block_one_image' ) ) : ?>
-				<img src="<?php echo esc_url( get_theme_mod('petals_block_one_image') ); ?>">
-			<?php endif; ?>
-			<?php if ( ! get_theme_mod( 'petals_block_one_image' ) ) : ?>
-			<img src="<?php echo esc_url( get_template_directory_uri().'/resources/mountains.png' ) ?>">
-			<?php endif; ?>
+			<?php if (get_theme_mod('petals_block_one_image')): ?>
+				<img src="<?php echo esc_url(get_theme_mod('petals_block_one_image')); ?>">
+			<?php
+            endif; ?>
+			<?php if (!get_theme_mod('petals_block_one_image')): ?>
+			<img src="<?php echo esc_url(get_template_directory_uri() . '/resources/mountains.png') ?>">
+			<?php
+            endif; ?>
 			<div class="block-one-contents-wrapper">
-				<h2 class ="block-one-heading"> <?php echo esc_attr( get_theme_mod('petals_block_one_heading', __('Edit these in your Customizer', 'petals') ) ); ?></h2>
-				<p class ="block-one-text"> <?php echo esc_attr( get_theme_mod('petals_block_one_text', __('Create something beautiful that stands out to your readers using three blocks! These can be edited with great ease in your Customizer. See below for some inspiration.', 'petals') ) ); ?></p>
-				<?php if ( get_theme_mod( 'petals_block_one_cta', 1 ) ) : ?>
-				<a class="block-one-button promotion-button panel-button" href="<?php echo esc_url( get_theme_mod('petals_block_one_cta_link', '#' ) ); ?>">
-					<?php echo esc_attr( get_theme_mod('petals_block_one_cta_text', __('You can also add your own button!', 'petals' ) ) ); ?>
+				<h2 class ="block-one-heading"> <?php echo esc_attr(get_theme_mod('petals_block_one_heading', __('Edit these in your Customizer', 'petals'))); ?></h2>
+				<p class ="block-one-text"> <?php echo esc_attr(get_theme_mod('petals_block_one_text', __('Create something beautiful that stands out to your readers using three blocks! These can be edited with great ease in your Customizer. See below for some inspiration.', 'petals'))); ?></p>
+				<?php if (get_theme_mod('petals_block_one_cta', 1)): ?>
+				<a class="block-one-button promotion-button panel-button" href="<?php echo esc_url(get_theme_mod('petals_block_one_cta_link', '#')); ?>">
+					<?php echo esc_attr(get_theme_mod('petals_block_one_cta_text', __('You can also add your own button!', 'petals'))); ?>
 				</a>
-				<?php endif; ?>
+				<?php
+            endif; ?>
 			</div>
 		</div>
-	<?php endif; ?>
-	<?php if ( get_theme_mod( 'petals_display_block_two', 0 ) == 1 ) : ?>
+	<?php
+        endif; ?>
+	<?php if (get_theme_mod('petals_display_block_two', 0) == 1): ?>
 		<div class="petals-block-two">
 			<div class="block-two-contents-wrapper">
-				<h2 class ="block-two-heading"> <?php echo esc_attr( get_theme_mod('petals_block_two_heading', __('Sunsets of a Lifetime', 'petals') ) ); ?></h2>
-				<p class ="block-two-text"> <?php echo esc_attr( get_theme_mod('petals_block_two_text', __('Each evening, the sun gently lowers itself down for the night, leaving some remarkable sights to enjoy, and offering the chance to take some fantastic pictures. ', 'petals') ) ); ?></p>
-				<?php if ( get_theme_mod( 'petals_block_two_cta', 1 ) == 1 ) : ?> 
-				<a class="block-two-button promotion-button panel-button" href="<?php echo esc_attr( get_theme_mod('petals_block_two_cta_link', __('Enter your own button here', 'petals' ) ) ); ?>">
-					<?php echo esc_attr( get_theme_mod('petals_block_two_cta_text', __('Enter your own button here', 'petals' ) ) ); ?>
+				<h2 class ="block-two-heading"> <?php echo esc_attr(get_theme_mod('petals_block_two_heading', __('Sunsets of a Lifetime', 'petals'))); ?></h2>
+				<p class ="block-two-text"> <?php echo esc_attr(get_theme_mod('petals_block_two_text', __('Each evening, the sun gently lowers itself down for the night, leaving some remarkable sights to enjoy, and offering the chance to take some fantastic pictures. ', 'petals'))); ?></p>
+				<?php if (get_theme_mod('petals_block_two_cta', 1) == 1): ?> 
+				<a class="block-two-button promotion-button panel-button" href="<?php echo esc_attr(get_theme_mod('petals_block_two_cta_link', __('Enter your own button here', 'petals'))); ?>">
+					<?php echo esc_attr(get_theme_mod('petals_block_two_cta_text', __('Enter your own button here', 'petals'))); ?>
 				</a>
-				<?php endif; ?>
+				<?php
+            endif; ?>
 			</div>
-			<?php if ( get_theme_mod( 'petals_block_two_image' ) ) : ?>
-				<img src="<?php echo esc_url( get_theme_mod('petals_block_two_image') ); ?>">
-			<?php endif; ?>
-			<?php if ( ! get_theme_mod( 'petals_block_two_image' ) ) : ?>
-			<img src="<?php echo esc_url( get_template_directory_uri().'/resources/sunset.png' ) ?>">
-			<?php endif; ?>
+			<?php if (get_theme_mod('petals_block_two_image')): ?>
+				<img src="<?php echo esc_url(get_theme_mod('petals_block_two_image')); ?>">
+			<?php
+            endif; ?>
+			<?php if (!get_theme_mod('petals_block_two_image')): ?>
+			<img src="<?php echo esc_url(get_template_directory_uri() . '/resources/sunset.png') ?>">
+			<?php
+            endif; ?>
 		</div>
-	<?php endif; ?>
-		<?php if ( get_theme_mod( 'petals_display_block_three', 0 ) == 1 ) : ?>
+	<?php
+        endif; ?>
+		<?php if (get_theme_mod('petals_display_block_three', 0) == 1): ?>
 		<div class="petals-block-three">
-			<?php if ( get_theme_mod( 'petals_block_three_image' ) ) : ?>
-				<img src="<?php echo esc_url( get_theme_mod('petals_block_three_image') ); ?>">
-			<?php endif; ?>
-			<?php if ( ! get_theme_mod( 'petals_block_three_image' ) ) : ?>
-			<img src="<?php echo esc_url( get_template_directory_uri().'/resources/items.png' ) ?>">
-			<?php endif; ?>
+			<?php if (get_theme_mod('petals_block_three_image')): ?>
+				<img src="<?php echo esc_url(get_theme_mod('petals_block_three_image')); ?>">
+			<?php
+            endif; ?>
+			<?php if (!get_theme_mod('petals_block_three_image')): ?>
+			<img src="<?php echo esc_url(get_template_directory_uri() . '/resources/items.png') ?>">
+			<?php
+            endif; ?>
 			<div class="block-three-contents-wrapper">
-				<h2 class ="block-three-heading"> <?php echo esc_attr( get_theme_mod('petals_block_three_heading', __('Shop', 'petals') ) ); ?></h2>
-				<p class ="block-three-text"> <?php echo esc_attr( get_theme_mod('petals_block_three_text', __('Each tour concludes with a visit to the gift shop, filled with merchandise created by the local villages. Items are unique, hand-crafted and make the perfect gift for all. You can also visit our online store.', 'petals') ) ); ?></p>
-				<?php if ( get_theme_mod( 'petals_block_three_cta', 1 ) == 1 ) : ?> 
-				<a class="block-three-button promotion-button panel-button" href="<?php echo esc_url( get_theme_mod('petals_block_three_cta_link', '#') ) ; ?>">
-					<?php echo esc_attr( get_theme_mod('petals_block_three_cta_text', __('Purchase now!', 'petals' ) ) ); ?>
+				<h2 class ="block-three-heading"> <?php echo esc_attr(get_theme_mod('petals_block_three_heading', __('Shop', 'petals'))); ?></h2>
+				<p class ="block-three-text"> <?php echo esc_attr(get_theme_mod('petals_block_three_text', __('Each tour concludes with a visit to the gift shop, filled with merchandise created by the local villages. Items are unique, hand-crafted and make the perfect gift for all. You can also visit our online store.', 'petals'))); ?></p>
+				<?php if (get_theme_mod('petals_block_three_cta', 1) == 1): ?> 
+				<a class="block-three-button promotion-button panel-button" href="<?php echo esc_url(get_theme_mod('petals_block_three_cta_link', '#')); ?>">
+					<?php echo esc_attr(get_theme_mod('petals_block_three_cta_text', __('Purchase now!', 'petals'))); ?>
 				</a>
-				<?php endif; ?>
+				<?php
+            endif; ?>
 			</div>
 		</div>
-	<?php endif; ?>
-	<?php endif; ?>
+	<?php
+        endif; ?>
+	<?php
+    endif; ?>
 	</div>
-	<?php endif; ?>
+	<?php
+endif; ?>
 	<div id="content" class="site-content">

--- a/header.php
+++ b/header.php
@@ -39,7 +39,7 @@ endif; ?>
 wp_nav_menu(array('theme_location' => 'menu-1', 'menu_id' => 'primary-menu',));
 ?>
 		</nav>
-		<?php if (is_front_page()): ?>
+		<?php if (!is_paged() && is_front_page()): ?>
 			<?php the_custom_logo(); ?>
 			<?php
     $petals_description = get_bloginfo('description', 'display');
@@ -66,8 +66,8 @@ wp_nav_menu(array('theme_location' => 'menu-1', 'menu_id' => 'primary-menu',));
 			<h6 class="small-panel-text"> <?php echo esc_attr(get_theme_mod('petals_small_text', __('This can be edited from your Customizer', 'petals'))); ?> </h6>
 			<h1 class="top-panel-text"> <?php echo esc_attr(get_theme_mod('petals_top_text', __('Wildlife & Floral Exhibition', 'petals'))); ?> </h1>
 			<h3 class ="bottom-panel-text"> <?php echo esc_attr(get_theme_mod('petals_bottom_text', __('Members Exclusive', 'petals'))); ?> </h3>
-			<?php if (get_theme_mod('petals_panel_button') == 1): ?> 
-			<a class="panel-button button" href="<?php echo esc_attr(get_theme_mod('petals_panel_buttonlink', __('Enter your own button here', 'petals'))); ?>">
+			<?php if (get_theme_mod('petals_panel_button', 1) == 1): ?> 
+			<a class="panel-button button" href="<?php echo esc_attr(get_theme_mod('petals_panel_buttonlink', '#', 'petals')); ?>">
 					<?php echo esc_attr(get_theme_mod('petals_panel_buttontext', __('Enter your own button here', 'petals'))); ?>
 			</a>
 			<?php
@@ -81,7 +81,7 @@ wp_nav_menu(array('theme_location' => 'menu-1', 'menu_id' => 'primary-menu',));
     } ?> <!-- #site-navigation -->
 		</div>
 	</header><!-- #masthead -->
-	<?php if (get_theme_mod('petals_display_promotion', 1) == 1): ?>
+	<?php if (!is_paged() && get_theme_mod('petals_display_promotion', 1) == 1): ?>
 	<div class="petals-promotion">
 		<?php if (get_theme_mod('petals_promotion_image')): ?>
 		<div class="promotion-image centrebg" style="background-image: url(<?php echo esc_url(get_theme_mod('petals_promotion_image')); ?>)">
@@ -105,7 +105,7 @@ wp_nav_menu(array('theme_location' => 'menu-1', 'menu_id' => 'primary-menu',));
 	</div>
 	<?php
     endif; ?>
-	<?php if (!is_home()): ?>
+	<?php if (!is_home() && !is_paged()): ?>
 	<div class="petals-block-wrapper">
 	<?php if (get_theme_mod('petals_display_block_one', 1) == 1): ?>
 		<div class="petals-block-one">

--- a/header.php
+++ b/header.php
@@ -105,7 +105,7 @@ wp_nav_menu(array('theme_location' => 'menu-1', 'menu_id' => 'primary-menu',));
 	</div>
 	<?php
     endif; ?>
-	<?php if (!is_home() && !is_paged()): ?>
+	<?php if (is_home() && !is_paged()): ?>
 	<div class="petals-block-wrapper">
 	<?php if (get_theme_mod('petals_display_block_one', 1) == 1): ?>
 		<div class="petals-block-one">

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -33,7 +33,7 @@ function petals_customize_register( $wp_customize ) {
 
 	$wp_customize->add_panel( 'petals_theme_options' , array(
     		'title'      => __( 'Theme Options', 'petals' ),
-    		'priority'   => 30,
+    		'priority'   => 1,
 	) );
 	
 	$wp_customize->add_setting( 'petals_link_colour', array(

--- a/readme.txt
+++ b/readme.txt
@@ -30,6 +30,12 @@ Petals includes support for Jetpack's Infinite Scrolling, Social Menu, and Conte
 
 == Changelog ==
 
+= 1.3 - Sep 01 2019 =
+* Fixes an issue for content boxes overflowing when lacking a sidebar 
+* Removes content created in the Customizer when beyond page one using Pagination
+* Prevents the site title overlapping with the mobile menu icon
+* Resolves an issue with the CTA button linking to a page by default
+
 = 1.2 - July 22 2019 =
 * Adds alt tags for Featured Images
 * Call the new wp_body_open function

--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ Petals includes support for Jetpack's Infinite Scrolling, Social Menu, and Conte
 
 = 1.3 - Sep 01 2019 =
 * Fixes an issue for content boxes overflowing when lacking a sidebar 
-* Removes content created in the Customizer when beyond page one using Pagination
+* Removes content created in the Customizer when beyond page one using Pagination, whilst fixing it from not appearing
 * Prevents the site title overlapping with the mobile menu icon
 * Resolves an issue with the CTA button linking to a page by default
 

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,7 @@ Petals includes support for Jetpack's Infinite Scrolling, Social Menu, and Conte
 * Prevents the site title overlapping with the mobile menu icon
 * Resolves an issue with the CTA button linking to a page by default
 * Improve clarity of Theme Options' location in the Customizer by increasing priority and changing colours
+* Ensure the menu wraps properly regardless of the site title's length
 
 = 1.2 - July 22 2019 =
 * Adds alt tags for Featured Images

--- a/readme.txt
+++ b/readme.txt
@@ -35,6 +35,7 @@ Petals includes support for Jetpack's Infinite Scrolling, Social Menu, and Conte
 * Removes content created in the Customizer when beyond page one using Pagination, whilst fixing it from not appearing
 * Prevents the site title overlapping with the mobile menu icon
 * Resolves an issue with the CTA button linking to a page by default
+* Improve clarity of Theme Options' location in the Customizer by increasing priority and changing colours
 
 = 1.2 - July 22 2019 =
 * Adds alt tags for Featured Images

--- a/rtl.css
+++ b/rtl.css
@@ -22,8 +22,7 @@ body {
 	float: right;
 }
 
-.widget-area,
-.menu {
+.widget-area {
 	float: left;
 }
 

--- a/style.css
+++ b/style.css
@@ -1213,6 +1213,10 @@ article {
 	width: auto;
 }
 
+.paged.no-sidebar .content-area {
+	margin-left: 50px;
+}
+
 .page .main-navigation {
 	background-color: rgba(255, 255, 255, 0.75);
 }
@@ -1468,7 +1472,8 @@ object {
 	
 	.widget-area,
 	.content-area,
-	.no-sidebar .content-area {
+	.no-sidebar .content-area,
+	.paged.no-sidebar .content-area {
 		margin-right: 20px;
 		margin-left: 20px;
 		max-width: calc(100% - 40px);
@@ -1510,6 +1515,7 @@ object {
 	
 	.site-branding h1 {
 		margin-left: 0;
+		max-width: 95%;
 	}
 	
 	.custom-header {

--- a/style.css
+++ b/style.css
@@ -667,7 +667,6 @@ p.has-text-color a {
 }
 
 .menu {
-	float: right;
 	margin-top: 10px;
 }
 

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@ Theme Name: Petals
 Theme URI: https://github.com/Aurorum/petals-theme
 Author: Aurorum
 Description: Petals is a landing-style theme designed to entice your readers, whilst also being simple to set up in the Customizer. Allowing your site to make a bold impact with a variety of options including a different header design, Petals empowers your website with options to enhance your dream. 
-Version: 1.2
+Version: 1.3
 License: GNU General Public License v2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: petals
@@ -642,6 +642,11 @@ a:hover, a:active {
 	outline: 0;
 }
 
+p.has-text-color a {
+	/* Ideally, this would be in core. Core PR: #17006 */
+	text-decoration: underline;
+}
+
 /*--------------------------------------------------------------
 ## Menus
 --------------------------------------------------------------*/
@@ -1205,6 +1210,7 @@ article {
 .no-sidebar .content-area {
 	margin-right: 90px;
 	max-width: none;
+	width: auto;
 }
 
 .page .main-navigation {
@@ -1461,7 +1467,8 @@ object {
 	}
 	
 	.widget-area,
-	.content-area {
+	.content-area,
+	.no-sidebar .content-area {
 		margin-right: 20px;
 		margin-left: 20px;
 		max-width: calc(100% - 40px);


### PR DESCRIPTION
**Changelog:**

* Fixes an issue for content boxes overflowing when lacking a sidebar 
* Removes content created in the Customizer when beyond page one using Pagination, whilst fixing it from not appearing
* Prevents the site title overlapping with the mobile menu icon
* Resolves an issue with the CTA button linking to a page by default
* Improve clarity of Theme Options' location in the Customizer by increasing priority and changing colours
* Ensure the menu wraps properly regardless of the site title's length